### PR TITLE
rootless: Fix SIGBUS when copying 8bit window contents upwards

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2188,7 +2188,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
             PixmapPtr pPix = (*pDraw->pScreen->GetWindowPixmap) (pWin);
 
             pBoundingDraw = &pPix->drawable;
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
             relx -= pPix->screen_x;
             rely -= pPix->screen_y;
 #endif

--- a/exa/exa.c
+++ b/exa/exa.c
@@ -125,7 +125,7 @@ exaGetDrawablePixmap(DrawablePtr pDrawable)
 void
 exaGetDrawableDeltas(DrawablePtr pDrawable, PixmapPtr pPixmap, int *xp, int *yp)
 {
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     if (pDrawable->type == DRAWABLE_WINDOW) {
         *xp = -pPixmap->screen_x;
         *yp = -pPixmap->screen_y;

--- a/exa/exa_accel.c
+++ b/exa/exa_accel.c
@@ -963,7 +963,7 @@ exaCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
     RegionInit(&rgnDst, NullBox, 0);
 
     RegionIntersect(&rgnDst, &pWin->borderClip, prgnSrc);
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     if (pPixmap->screen_x || pPixmap->screen_y)
         RegionTranslate(&rgnDst, -pPixmap->screen_x, -pPixmap->screen_y);
 #endif

--- a/fb/fb.h
+++ b/fb/fb.h
@@ -441,7 +441,7 @@ typedef struct {
 #define __fbPixDrawableX(pPix)	((pPix)->drawable.x)
 #define __fbPixDrawableY(pPix)	((pPix)->drawable.y)
 
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
 #define __fbPixOffXWin(pPix)	(__fbPixDrawableX(pPix) - (pPix)->screen_x)
 #define __fbPixOffYWin(pPix)	(__fbPixDrawableY(pPix) - (pPix)->screen_y)
 #else

--- a/fb/fbpixmap.c
+++ b/fb/fbpixmap.c
@@ -76,7 +76,7 @@ fbCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     fbInitializeDrawable(&pPixmap->drawable);
 #endif
 
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     pPixmap->screen_x = 0;
     pPixmap->screen_y = 0;
 #endif

--- a/fb/fbwindow.c
+++ b/fb/fbwindow.c
@@ -116,7 +116,7 @@ fbCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
 
     RegionIntersect(&rgnDst, &pWin->borderClip, prgnSrc);
 
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     if (pPixmap->screen_x || pPixmap->screen_y)
         RegionTranslate(&rgnDst, -pPixmap->screen_x, -pPixmap->screen_y);
 #endif

--- a/glamor/glamor_copy.c
+++ b/glamor/glamor_copy.c
@@ -781,7 +781,7 @@ glamor_copy_window(WindowPtr window, DDXPointRec old_origin, RegionPtr src_regio
 
     RegionIntersect(&dst_region, &window->borderClip, src_region);
 
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     if (pixmap->screen_x || pixmap->screen_y)
         RegionTranslate(&dst_region, -pixmap->screen_x, -pixmap->screen_y);
 #endif

--- a/glamor/glamor_pixmap.c
+++ b/glamor/glamor_pixmap.c
@@ -39,7 +39,7 @@ void
 glamor_get_drawable_deltas(DrawablePtr drawable, PixmapPtr pixmap,
                            int *x, int *y)
 {
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     if (drawable->type == DRAWABLE_WINDOW) {
         *x = -pixmap->screen_x;
         *y = -pixmap->screen_y;

--- a/glx/glxext.c
+++ b/glx/glxext.c
@@ -281,24 +281,6 @@ GlxPushProvider(__GLXprovider * provider)
     __glXProviderStack = provider;
 }
 
-static Bool
-checkScreenVisuals(void)
-{
-    int i, j;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr screen = screenInfo.screens[i];
-        for (j = 0; j < screen->numVisuals; j++) {
-            if ((screen->visuals[j].class == TrueColor ||
-                 screen->visuals[j].class == DirectColor) &&
-                screen->visuals[j].nplanes > 12)
-                return TRUE;
-        }
-    }
-
-    return FALSE;
-}
-
 static void
 GetGLXDrawableBytes(void *value, XID id, ResourceSizePtr size)
 {
@@ -472,10 +454,6 @@ static Bool
 xorgGlxServerPreInit(const ExtensionEntry *extEntry)
 {
     if (glxGeneration != serverGeneration) {
-        /* Mesa requires at least one True/DirectColor visual */
-        if (!checkScreenVisuals())
-            return FALSE;
-
         __glXContextRes = CreateNewResourceType((DeleteType) ContextGone,
                                                 "GLXContext");
         __glXDrawableRes = CreateNewResourceType((DeleteType) DrawableGone,

--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -790,6 +790,9 @@ create_thread(void *(*func)(void *), void *arg)
     pthread_attr_init(&attr);
     pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+    }
     pthread_create(&tid, &attr, func, arg);
     pthread_attr_destroy(&attr);
 

--- a/hw/xquartz/darwinEvents.c
+++ b/hw/xquartz/darwinEvents.c
@@ -129,6 +129,9 @@ create_thread(void *(*func)(void *), void *arg)
     pthread_attr_init(&attr);
     pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+    }
     pthread_create(&tid, &attr, func, arg);
     pthread_attr_destroy(&attr);
 

--- a/hw/xquartz/quartzStartup.c
+++ b/hw/xquartz/quartzStartup.c
@@ -74,6 +74,9 @@ create_thread(void *func, void *arg)
     pthread_attr_init(&attr);
     pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INTERACTIVE, 0);
+    }
     pthread_create(&tid, &attr, func, arg);
     pthread_attr_destroy(&attr);
 

--- a/include/pixmapstr.h
+++ b/include/pixmapstr.h
@@ -78,7 +78,7 @@ typedef struct _Pixmap {
     int refcnt;
     int devKind;                /* This is the pitch of the pixmap, typically width*bpp/8. */
     DevUnion devPrivate;        /* When !NULL, devPrivate.ptr points to the raw pixel data. */
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     short screen_x;
     short screen_y;
 #endif

--- a/mi/miexpose.c
+++ b/mi/miexpose.c
@@ -461,7 +461,7 @@ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
         tile_x_off = pWin->drawable.x;
         tile_y_off = pWin->drawable.y;
 
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
         draw_x_off = pixmap->screen_x;
         draw_y_off = pixmap->screen_y;
         tile_x_off -= draw_x_off;

--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -142,7 +142,7 @@ damageRegionAppend(DrawablePtr pDrawable, RegionPtr pRegion, Bool clip,
     RegionRec pixClip;
     int draw_x, draw_y;
 
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     int screen_x = 0, screen_y = 0;
 #endif
 
@@ -150,7 +150,7 @@ damageRegionAppend(DrawablePtr pDrawable, RegionPtr pRegion, Bool clip,
     if (!RegionNotEmpty(pRegion))
         return;
 
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     /*
      * When drawing to a pixmap which is storing window contents,
      * the region presented is in pixmap relative coordinates which
@@ -201,7 +201,7 @@ damageRegionAppend(DrawablePtr pDrawable, RegionPtr pRegion, Bool clip,
 
         draw_x = pDamage->pDrawable->x;
         draw_y = pDamage->pDrawable->y;
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
         /*
          * Need to move everyone to screen coordinates
          * XXX what about off-screen pixmaps with non-zero x/y?
@@ -274,7 +274,7 @@ damageRegionAppend(DrawablePtr pDrawable, RegionPtr pRegion, Bool clip,
         if (pDamageRegion == pRegion && (draw_x || draw_y))
             RegionTranslate(pDamageRegion, draw_x, draw_y);
     }
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
     if (screen_x || screen_y)
         RegionTranslate(pRegion, -screen_x, -screen_y);
 #endif

--- a/miext/rootless/README.txt
+++ b/miext/rootless/README.txt
@@ -88,14 +88,6 @@ rootlessConfig.h:
         the underlying window server. Most operations will be buffered until
         this time has expired.
 
-      o ROOTLESS_RESIZE_GRAVITY: If the underlying window system supports it,
-        some frame resizes can be optimized by relying on the frame contents
-        maintaining a particular gravity during the resize. In this way less
-        of the frame contents need to be preserved by the generic rootless
-        layer. If true, the generic rootless layer will pass gravity hints
-        during resizing and rely on the frame contents being preserved
-        accordingly.
-
         The following runtime options are defined in rootless.h:
 
       o rootlessGlobalOffsetX, rootlessGlobalOffsetY: These specify the global

--- a/miext/rootless/rootless.h
+++ b/miext/rootless/rootless.h
@@ -140,8 +140,7 @@ typedef void (*RootlessMoveFrameProc)
  *  pScreen     Screen to move the new frame to
  *  newX, newY  New position of the frame
  *  newW, newH  New size of the frame
- *  gravity     Gravity for window contents (rl_gravity_enum). This is always
- *              RL_GRAVITY_NONE unless ROOTLESS_RESIZE_GRAVITY is set.
+ *  gravity     Gravity for window contents (rl_gravity_enum).
  */
 typedef void (*RootlessResizeFrameProc)
  (RootlessFrameID wid, ScreenPtr pScreen,

--- a/miext/rootless/rootlessCommon.h
+++ b/miext/rootless/rootlessCommon.h
@@ -229,20 +229,10 @@ extern RegionRec rootlessHugeRoot;
  *  Can't access the bits before the first word of the drawable's data in
  *  rootless mode, so make sure our base address is always 32-bit aligned.
  */
-#define SetPixmapBaseToScreen(pix, _x, _y) {                                \
-    PixmapPtr   _pPix = (PixmapPtr) (pix);                                  \
-    _pPix->devPrivate.ptr = (char *) (_pPix->devPrivate.ptr) -              \
-                            ((int)(_x) * _pPix->drawable.bitsPerPixel/8 +   \
-                             (int)(_y) * _pPix->devKind);                   \
-    if (_pPix->drawable.bitsPerPixel != FB_UNIT) {                          \
-        size_t _diff = ((size_t) _pPix->devPrivate.ptr) &               \
-                         (FB_UNIT / CHAR_BIT - 1);                          \
-        _pPix->devPrivate.ptr = (char *) (_pPix->devPrivate.ptr) -          \
-                                _diff;                                      \
-        _pPix->drawable.x = _diff /                                         \
-                            (_pPix->drawable.bitsPerPixel / CHAR_BIT);      \
-    }                                                                       \
-}
+#define SetPixmapBaseToScreen(pix, _x, _y) do { \
+    pix->screen_x = _x; \
+    pix->screen_y = _y; \
+} while(0)
 
 // Returns TRUE if this window is visible inside a frame
 // (e.g. it is visible and has a top-level or root parent)

--- a/miext/rootless/rootlessCommon.h
+++ b/miext/rootless/rootlessCommon.h
@@ -285,4 +285,5 @@ void RootlessDisableRoot(ScreenPtr pScreen);
 
 void RootlessSetPixmapOfAncestors(WindowPtr pWin);
 
+unsigned long RootlessWID(WindowPtr pWindow);
 #endif                          /* _ROOTLESSCOMMON_H */

--- a/miext/rootless/rootlessConfig.h
+++ b/miext/rootless/rootlessConfig.h
@@ -34,10 +34,6 @@
 #ifndef _ROOTLESSCONFIG_H
 #define _ROOTLESSCONFIG_H
 
-#ifdef __APPLE__
-#define ROOTLESS_RESIZE_GRAVITY TRUE
-#endif
-
 /*# define ROOTLESSDEBUG*/
 
 #define ROOTLESS_PROTECT_ALPHA TRUE

--- a/miext/rootless/rootlessGC.c
+++ b/miext/rootless/rootlessGC.c
@@ -549,7 +549,7 @@ RootlessCopyArea(DrawablePtr pSrc, DrawablePtr dst, GCPtr pGC,
     GC_SAVE(pGC);
     GCOP_UNWRAP(pGC);
 
-    RL_DEBUG_MSG("copy area start (src 0x%x, dst 0x%x)", pSrc, dst);
+    RL_DEBUG_MSG("copy area start (src %p, dst %p)", pSrc, dst);
 
     if (pSrc->type == DRAWABLE_WINDOW && IsFramedWindow((WindowPtr) pSrc)) {
         /* If both source and dest are windows, and we're doing
@@ -800,7 +800,7 @@ static void
 RootlessPolySegment(DrawablePtr dst, GCPtr pGC, int nseg, xSegment * pSeg)
 {
     GCOP_UNWRAP(pGC);
-    RL_DEBUG_MSG("poly segment start (win 0x%x)", dst);
+    RL_DEBUG_MSG("poly segment start (dst %p)", dst);
 
     RootlessStartDrawing((WindowPtr) dst);
     pGC->ops->PolySegment(dst, pGC, nseg, pSeg);
@@ -998,7 +998,7 @@ RootlessFillPolygon(DrawablePtr dst, GCPtr pGC,
 {
     GC_SAVE(pGC);
     GCOP_UNWRAP(pGC);
-    RL_DEBUG_MSG("fill poly start (win 0x%x, fillStyle 0x%x)", dst,
+    RL_DEBUG_MSG("fill poly start (dst %p, fillStyle 0x%x)", dst,
                  pGC->fillStyle);
 
     if (count <= 2) {
@@ -1072,7 +1072,7 @@ RootlessPolyFillRect(DrawablePtr dst, GCPtr pGC,
 {
     GC_SAVE(pGC);
     GCOP_UNWRAP(pGC);
-    RL_DEBUG_MSG("fill rect start (win 0x%x, fillStyle 0x%x)", dst,
+    RL_DEBUG_MSG("fill rect start (dst %p, fillStyle 0x%x)", dst,
                  pGC->fillStyle);
 
     if (nRectsInit <= 0) {

--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -326,8 +326,8 @@ RootlessGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
     //SCREEN_WRAP(ps, Glyphs);
 
     if (dstWin && IsFramedWindow(dstWin)) {
-        x = xSrc;
-        y = ySrc;
+        x = 0;
+        y = 0;
 
         while (nlist--) {
             x += list->xOff;
@@ -370,6 +370,11 @@ RootlessGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
                     y += glyph->info.yOff;
                 }
 
+                /* RootlessDamageBox expects global (screen) coordinates */
+                box.x1 += dstWin->drawable.x;
+                box.y1 += dstWin->drawable.y;
+                box.x2 += dstWin->drawable.x;
+                box.y2 += dstWin->drawable.y;
                 RootlessDamageBox(dstWin, &box);
             }
             list++;

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -705,11 +705,17 @@ RootlessCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
     else {
         RootlessStartDrawing(pWin);
 
-        miCopyRegion((DrawablePtr) pWin, (DrawablePtr) pWin,
+        PixmapPtr pPixmap = pScreen->GetWindowPixmap(pWin);
+        DrawablePtr pDrawable = &pPixmap->drawable;
+
+        if (pPixmap->screen_x || pPixmap->screen_y) {
+            RegionTranslate(&rgnDst, -pPixmap->screen_x, -pPixmap->screen_y);
+        }
+
+        miCopyRegion(pDrawable, pDrawable,
                      0, &rgnDst, dx, dy, fbCopyWindowProc, 0, 0);
 
-        /* prgnSrc has been translated to dst position */
-        RootlessDamageRegion(pWin, prgnSrc);
+        RootlessDamageRegion(pWin, &rgnDst);
     }
 
  out:

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -1012,7 +1012,12 @@ StartFrameResize(WindowPtr pWin, Bool gravity,
     }
     else if (gravity) {
         /* The general case. Just copy everything. */
+        need_window_source = TRUE;
+    }
 
+    /* If necessary, create a source pixmap pointing at the current
+       window bits. */
+    if (need_window_source) {
         RootlessStartDrawing(pWin);
 
         gResizeDeathBits = xallocarray(winRec->bytesPerRow, winRec->height);
@@ -1053,21 +1058,6 @@ StartFrameResize(WindowPtr pWin, Bool gravity,
     }
 
     RootlessStartDrawing(pWin);
-
-    /* If necessary, create a source pixmap pointing at the current
-       window bits. */
-
-    if (need_window_source) {
-        gResizeDeathBounds[0] = (BoxRec) {
-        oldX, oldY, oldX2, oldY2};
-        gResizeDeathPix[0]
-            = GetScratchPixmapHeader(pScreen, oldW, oldH,
-                                     winRec->win->drawable.depth,
-                                     winRec->win->drawable.bitsPerPixel,
-                                     winRec->bytesPerRow, winRec->pixelData);
-
-        SetPixmapBaseToScreen(gResizeDeathPix[0], oldX, oldY);
-    }
 
     /* Use custom CopyWindow when moving gravity bits around
        ResizeWindow assumes the old window contents are in the same

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -325,7 +325,7 @@ RootlessPositionWindow(WindowPtr pWin, int x, int y)
     RootlessWindowRec *winRec = WINREC(pWin);
     Bool result;
 
-    RL_DEBUG_MSG("positionwindow start (win 0x%x @ %i, %i)\n", pWin, x, y);
+    RL_DEBUG_MSG("positionwindow start (win %p (%lu) @ %i, %i)\n", pWin, RootlessWID(pWin), x, y);
 
     if (winRec) {
         if (winRec->is_drawing) {
@@ -441,7 +441,7 @@ RootlessRealizeWindow(WindowPtr pWin)
     RegionRec saveRoot;
     ScreenPtr pScreen = pWin->drawable.pScreen;
 
-    RL_DEBUG_MSG("realizewindow start (win 0x%x) ", pWin);
+    RL_DEBUG_MSG("realizewindow start (win %p (%lu)) ", pWin, RootlessWID(pWin));
 
     if ((IsTopLevel(pWin) && pWin->drawable.class == InputOutput)) {
         RootlessWindowRec *winRec;
@@ -664,7 +664,7 @@ RootlessResizeCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg,
     RegionRec rgnDst;
     int dx, dy;
 
-    RL_DEBUG_MSG("resizecopywindowFB start (win 0x%x) ", pWin);
+    RL_DEBUG_MSG("resizecopywindowFB start (win %p (%lu)) ", pWin, RootlessWID(pWin));
 
     /* Don't unwrap pScreen->CopyWindow.
        The bogus rewrap with RootlessCopyWindow causes a crash if
@@ -733,7 +733,7 @@ RootlessCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
     BoxPtr extents;
     int area;
 
-    RL_DEBUG_MSG("copywindowFB start (win 0x%x) ", pWin);
+    RL_DEBUG_MSG("copywindowFB start (win %p (%lu)) ", pWin, RootlessWID(pWin));
 
     SCREEN_UNWRAP(pScreen, CopyWindow);
 
@@ -1268,7 +1268,7 @@ RootlessResizeWindow(WindowPtr pWin, int x, int y,
     Bool resize_after = FALSE;
     RegionRec saveRoot;
 
-    RL_DEBUG_MSG("resizewindow start (win 0x%x) ", pWin);
+    RL_DEBUG_MSG("resizewindow start (win %p (%lu)) ", pWin, RootlessWID(pWin));
 
     if (pWin->parent) {
         if (winRec) {
@@ -1649,7 +1649,7 @@ RootlessSetPixmapOfAncestors(WindowPtr pWin)
             XID pixel = 0;
 
             ChangeWindowAttributes(pWin, CWBackPixel, &pixel, serverClient);
-            RL_DEBUG_MSG("Cleared ParentRelative on 0x%x.\n", pWin);
+            RL_DEBUG_MSG("Cleared ParentRelative on %p (%lu).\n", pWin, RootlessWID(pWin));
             break;
         }
 

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -845,7 +845,7 @@ ResizeWeighting(int oldX1, int oldY1, int oldX2, int oldY2, int oldBW,
     else if (newX2 == oldX2 && newY1 == oldY1)
         return RL_GRAVITY_NORTH_EAST;
     else
-        return RL_GRAVITY_NONE;
+        return RL_GRAVITY_NORTH_WEST;
 }
 
 /*

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -949,43 +949,6 @@ StartFrameResize(WindowPtr pWin, Bool gravity,
         gResizeOldCopyWindowProc = pScreen->CopyWindow;
         pScreen->CopyWindow = RootlessResizeCopyWindow;
     }
-
-    /* If we can't rely on the window server preserving the bits we
-       need in the position we need, copy the pixels in the
-       intersection from src to dst. ResizeWindow assumes these pixels
-       are already present when making gravity adjustments. pWin
-       currently has new-sized pixmap but is in old position.
-
-       FIXME: border width change! (?) */
-
-    if (gravity && weight == RL_GRAVITY_NONE) {
-        PixmapPtr src, dst;
-
-        assert(gResizeDeathCount == 1);
-
-        src = gResizeDeathPix[0];
-        dst = pScreen->GetWindowPixmap(pWin);
-
-        RL_DEBUG_MSG("Resize copy rect %d %d %d %d\n",
-                     rect.x1, rect.y1, rect.x2, rect.y2);
-
-        /* rect is the intersection of the old location and new location */
-        if (BOX_NOT_EMPTY(rect) && src != NULL && dst != NULL) {
-            /* The window drawable still has the old frame position, which
-               means that DST doesn't actually point at the origin of our
-               physical backing store when adjusted by the drawable.x,y
-               position. So sneakily adjust it temporarily while copying.. */
-
-            ((PixmapPtr) dst)->devPrivate.ptr = winRec->pixelData;
-            SetPixmapBaseToScreen(dst, newX, newY);
-
-            fbCopyWindowProc(&src->drawable, &dst->drawable, NULL,
-                             &rect, 1, 0, 0, FALSE, FALSE, 0, 0);
-
-            ((PixmapPtr) dst)->devPrivate.ptr = winRec->pixelData;
-            SetPixmapBaseToScreen(dst, oldX, oldY);
-        }
-    }
 }
 
 static void

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -833,7 +833,6 @@ static inline unsigned int
 ResizeWeighting(int oldX1, int oldY1, int oldX2, int oldY2, int oldBW,
                 int newX1, int newY1, int newX2, int newY2, int newBW)
 {
-#ifdef ROOTLESS_RESIZE_GRAVITY
     if (newBW != oldBW)
         return RL_GRAVITY_NONE;
 
@@ -847,9 +846,6 @@ ResizeWeighting(int oldX1, int oldY1, int oldX2, int oldY2, int oldBW,
         return RL_GRAVITY_NORTH_EAST;
     else
         return RL_GRAVITY_NONE;
-#else
-    return RL_GRAVITY_NONE;
-#endif
 }
 
 /*

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -737,6 +737,11 @@ RootlessCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
         miCopyRegion(pDrawable, pDrawable,
                      0, &rgnDst, dx, dy, fbCopyWindowProc, 0, 0);
 
+        /* RootlessDamageRegion() wants global coordinates */
+        if (pPixmap->screen_x || pPixmap->screen_y) {
+            RegionTranslate(&rgnDst, pPixmap->screen_x, pPixmap->screen_y);
+        }
+
         RootlessDamageRegion(pWin, &rgnDst);
     }
 

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -645,6 +645,27 @@ RootlessNoCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
 }
 
 /*
+ * RootlessCanAccelerateCopy
+ *  Returns TRUE if the implementation may be asked to copy this window's
+ *  contents around.
+ *
+ *  8bit frames are excluded: libXplugin keeps those in a software backing
+ *  store of its own and _xp_backing_scroll() computes the destination
+ *  address of the copy with a 32bit (bytes_per_row * dy) multiply which it
+ *  then zero-extends.  Any copy moving content upwards is therefore done
+ *  ~4GB past the backing store and takes the server down with SIGBUS.
+ *  Nothing is lost by copying such windows ourselves, libXplugin would
+ *  only memcpy them as well.
+ */
+static Bool
+RootlessCanAccelerateCopy(WindowPtr pWin)
+{
+    WindowPtr top = TopLevelParent(pWin);
+
+    return top != NULL && top->drawable.depth != 8;
+}
+
+/*
  * RootlessCopyWindow
  *  Update *new* location of window. Old location is redrawn with
  *  PaintWindow. Cloned from fbCopyWindow.
@@ -677,6 +698,7 @@ RootlessCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
     /* If the area exceeds threshold, use the implementation's
        accelerated version. */
     if (area > rootless_CopyWindow_threshold &&
+        RootlessCanAccelerateCopy(pWin) &&
         SCREENREC(pScreen)->imp->CopyWindow) {
         RootlessWindowRec *winRec;
         WindowPtr top;

--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -192,11 +192,12 @@ WaitForSomething(Bool are_ready)
             ProcessWorkQueue();
         }
 
-        timeout = check_timers();
         are_ready = clients_are_ready();
 
         if (are_ready)
             timeout = 0;
+        else
+            timeout = check_timers();
 
         BlockHandler(&timeout);
         if (NewOutputPending)

--- a/os/inputthread.c
+++ b/os/inputthread.c
@@ -479,6 +479,12 @@ InputThreadInit(void)
     if (pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM) != 0)
         ErrorF("input-thread: error setting thread scope\n");
 
+#ifdef __APPLE__
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INTERACTIVE, 0);
+    }
+#endif
+
     DebugF("input-thread: creating thread\n");
     pthread_create(&inputThreadInfo->thread, &attr,
                    &InputThreadDoWork, NULL);

--- a/present/present_scmd.c
+++ b/present/present_scmd.c
@@ -115,7 +115,7 @@ present_check_flip(RRCrtcPtr            crtc,
 
     /* Does the window match the pixmap exactly? */
     if (window->drawable.x != 0 || window->drawable.y != 0 ||
-#ifdef COMPOSITE
+#if defined(COMPOSITE) || defined(ROOTLESS)
         window->drawable.x != pixmap->screen_x || window->drawable.y != pixmap->screen_y ||
 #endif
         window->drawable.width != pixmap->drawable.width ||

--- a/randr/randr.c
+++ b/randr/randr.c
@@ -414,9 +414,6 @@ RRExtensionInit(void)
 {
     ExtensionEntry *extEntry;
 
-    if (RRNScreens == 0)
-        return;
-
     if (!dixRegisterPrivateKey(&RRClientPrivateKeyRec, PRIVATE_CLIENT,
                                sizeof(RRClientRec) +
                                screenInfo.numScreens * sizeof(RRTimesRec)))


### PR DESCRIPTION
XQuartz in 8bit mode (`defaults write org.xquartz.X11 depth 8`) dies with SIGBUS whenever a child window is moved upwards and the copy exceeds `xp_scroll_area_threshold`:

```
Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Codes: KERN_PROTECTION_FAILURE at 0x00000002283111e0

0  libsystem_platform.dylib  _platform_memmove + 168
1  CoreGraphics              CGBlt_copyBytes + 496
2  libXplugin.1.dylib        _xp_backing_scroll + 156
3  libXplugin.1.dylib        xp_copy_window + 516
4  X11.bin                   RootlessCopyWindow + 752
5  X11.bin                   miSpriteCopyWindow + 168
6  X11.bin                   miMoveWindow + 388
```

`_xp_backing_scroll()` computes the destination as `src + (uint32)(bytes_per_row * dy) + dx`. The multiply is 32bit and gets zero extended, so a negative `dy` lands ~4GB past the backing store:

```
mul  w8, w4, w19        ; bytes_per_row * dy, 32bit -> zero extended
add  x8, x8, x22        ; + dx, sign extended
add  x3, x2, x8         ; dst = src + offset
```

In the report above: `dst - src == 0xFFFFF81F == (uint32)(-1952) + (-65)`, matching a 1952 byte stride, 1 row up, 65 px left.

Only `XP_DEPTH_INDEX8` frames reach that code, everything else is scrolled by the window server, which explains why this is 8bit only. So don't hand 8bit frames to the implementation's `CopyWindow` — libXplugin would only memcpy them anyway, so nothing is lost.

Second commit is a separate bug in the same function: since 74b8383 the region is damaged after being translated out of global coordinates, so `RootlessDamageRegion()` intersects it against `borderClip` and comes up empty for any frame not at the screen origin, and the copied contents are never flushed. It matters more now that 8bit copies always take this path.

Analysis is from the crash report plus libXplugin disassembly; not build tested yet.
