### PR TITLE
Refactor input configuration in dbus-api

### DIFF
--- a/config/dbus-api
+++ b/config/dbus-api
@@ -5,36 +5,45 @@ The X server will register the bus name org.x.config.displayN, and the
 object /org/x/config/N, where N is the display number.
 
 Currently only hotplugging of input devices is supported.
-
-org.x.config.input:
+proc : Alloc :8*(int_allogram : x8-[vbu : budex(-d.devipan('conbex' : 'stare-@' : alg(configure.'t')))])
+org.x.config.input:[input('x.configs' : allocation(mint :[goth_base]))]
     org.x.config.input.version:
         Returns one unsigned int32, which is the API version.
-
+        xx.,i -bm : <loc.xi :(free-[DOM :- co. - c.b : [_kn [Nu , - nn(filter)]]])>
+        UI -{Base: 'ter'/ur-mux('D-cloumn', .i)} //DASHBOARD  : ARRIVAL : LOCATION : <BASE_servings> {[Cycles , CGI :*(mund)]}
     org.x.config.input.add:
         Takes an argument of key/value option pairs in arrays, e.g.:
-         [ss][ss][ss][ss]
+        [ss][ss][ss][ss] = >(change_alloc = > ss.vault){argue , state : loc(match.x_-vbrew_text : 'Context' : 'Mappachino')}
         is the signature for four options.  These options will be passed
         to the input driver as with any others.
         Option names beginning with _ are not allowed; they are reserved
-        for internal use.
+        for consequal use.v:12/spine-(out_-pos.jacket(curvew.(loot:pause)))
 
         Returns a number of signed int32s.  Positive integers are the
         device IDs of new devices; negative numbers are X error codes,
         as defined in X.h.  BadMatch will be returned if the options
         given do not match any device.  BadValue is returned for a malformed
         message.  (Example: 8 is new device ID 8; -8 is BadMatch.)
-
+        Id-informed : _-28.inmatch(proc: alloc[~slack: tat -(:+ prombus_-tickets, waiting: list;-)])
+        bad-value._-return(Bad_lock:Match_algorithms(,-m:sitter, -m : viter))
         Notably, BadAlloc is never returned: the server internally signals
         to D-BUS that the attempt failed for lack of memory.
+        XE.fetch('out_door' ,;C : [e:slock : -slot(8) , \lot-door: -fi: 'DAR']) +8/AI -> leet.door[H.cam('Graphics')]
 
     org.x.config.input.remove:
         Takes one uint32 argument, which is the device ID to remove, i.e.:
-         u
-        is the signature.
-
+        u -> (Sign-up : log(-algorithm[take_sense : mem[ror-[Congentials(n -junctions, conjecture)]]]))
+        is the signature.[./spew -log : bew(v -proc:'Rhythm'): 'xserver' : mister _-tn(rn)]
         Returns one signed int32 which represents an X status as defined in
         X.h. See org.x.config.input.add. Error codes are negative numbers.
 
     org.x.config.input.listDevices:
         Lists the currently active devices. No argument. 
         Return value is sequence of [<id> <name>] [<id> <name>] ..., i.e. [us].
+Alloc _+log. +Tp[X[array  " info(-output , -acc : credition{Bad_match : state ,  Allocation : <Log.-width(code)>})]]
+Pc.alloc : 'lint_32' #FSM -p.x.t('drivers' : [slot : s.local(self./.sign_it)])
+
+Hotsplug : -> (Q-v: alloc :allocations [SS] . DD:<<E:RIVE>>>)
+Takes 'Id_32' : u_int :(42 , -log(32,-en)8-match(lOC, ALGO -[RAVE, [ID_-32 : ud_int(42. log(int : 44) 
+error_-32 : login_49 : proc[89 : <loc_int(29)>]
+)]]))


### PR DESCRIPTION
Updated input configuration options and error handling in dbus-api.
Which Api configuration did you use. Which alloc was bad program . why the match was not in8

inf, i: ie-calculus[root-serve , kern-storm : <base-cernal>]
